### PR TITLE
add isNaN validation at generateNextEvent.js

### DIFF
--- a/bin/generateNextEvent.js
+++ b/bin/generateNextEvent.js
@@ -4,7 +4,7 @@ var meetup_path = `${__dirname}/../meetups`
 fs.readdir( meetup_path, (err, dirs) => {
   var meetups = dirs
     .filter( (dir) => { return !/template/.test(dir) })
-    .map( dir => parseInt(dir) );
+    .map( dir => isNaN(dir) ? 0 : parseInt(dir) );
 
   var next_meetup_num = Math.max.apply(null, meetups) + 1;
 

--- a/bin/generateNextEvent.js
+++ b/bin/generateNextEvent.js
@@ -3,8 +3,8 @@ var meetup_path = `${__dirname}/../meetups`
 
 fs.readdir( meetup_path, (err, dirs) => {
   var meetups = dirs
-    .filter( (dir) => { return !/template/.test(dir) })
-    .map( dir => isNaN(dir) ? 0 : parseInt(dir) );
+    .filter( (dir) => { return /[0-9]+/.test(dir) })
+    .map( dir => parseInt(dir) );
 
   var next_meetup_num = Math.max.apply(null, meetups) + 1;
 


### PR DESCRIPTION
dirsを数字変換前
```
[ '.DS_Store',
  '1',
  '10',
  '11',
  '12',
  '13',
  '14',
  '15',
  '16',
  '17',
  '18',
  '19',
  '2',
  '20',
  '21',
  '22',
  '23',
  '4',
  '5',
  '6',
  '7',
  '8',
  '9',
  'template.md' ]
```
dirsを数字変換前
```
[ NaN,
  1,
  10,
  11,
  12,
  13,
  14,
  15,
  16,
  17,
  18,
  19,
  2,
  20,
  21,
  22,
  23,
  4,
  5,
  6,
  7,
  8,
  9,
  NaN ]
```

数字じゃないやつが混ざるとNaNになって `Math.max.apply`が必ずNaNを返すようになっていたので、数字じゃないやつは強制的に0を返すように処理を加えた