### PR TITLE
Work enable puppeteer on alpine container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     environment:
       GITHUB_API_TOKEN: ${GITHUB_API_TOKEN}
     volumes:
-      - ./:/app
+      - ./:/src
       - scripts_node_modules:/app/scripts/node_modules
 
 volumes:

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,33 @@
 FROM node:12-alpine
 
+# https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
+# Installs latest Chromium (77) package.
+RUN apk add --no-cache \
+      chromium \
+      nss \
+      freetype \
+      freetype-dev \
+      harfbuzz \
+      ca-certificates \
+      ttf-freefont \
+      nodejs \
+      yarn
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+# Puppeteer v1.19.0 works with Chromium 77.
+RUN yarn add puppeteer@1.19.0
+
+# Add user so we don't need --no-sandbox.
+RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
+    && mkdir -p /home/pptruser/Downloads /app \
+    && chown -R pptruser:pptruser /home/pptruser \
+    && chown -R pptruser:pptruser /app
+
+# Run everything after as non-privileged user.
+USER pptruser
+
 # Install entrykit
 ENV ENTRYKIT_VERSION 0.4.0
 RUN apk add --no-cache --virtual build-dependencies curl tar git \
@@ -11,7 +39,7 @@ RUN apk add --no-cache --virtual build-dependencies curl tar git \
   && chmod +x /bin/entrykit \
   && entrykit --symlink
 
-WORKDIR /app
+WORKDIR /src
 VOLUME /src/scripts/node_modules
 
 ENTRYPOINT [ \

--- a/scripts/connpass_event_creator.js
+++ b/scripts/connpass_event_creator.js
@@ -13,7 +13,11 @@ ConnpassEventCreator.create = async settings => {
   const user = process.env.CONNPASS_USER;
   const password = process.env.CONNPASS_PASSWORD;
 
-  const browser = await puppeteer.launch({ headless: true });
+  // const browser = await puppeteer.launch({ headless: true });
+  const browser = await puppeteer.launch({
+    executablePath: '/usr/bin/chromium-browser',
+    headless: true
+  });
   const page = await browser.newPage();
   await page.setViewport({ width: 1440, height: 766 });
 

--- a/scripts/event_publisher.js
+++ b/scripts/event_publisher.js
@@ -10,8 +10,8 @@ EventDirCreator.setup(process.env.GITHUB_API_TOKEN);
 
 const nextEventNum = EventDirCreator.getNextEventNum();
 
-EventDirCreator.createDirWithNum(nextEventNum);
-EventDirCreator.createPullRequestWithNum(nextEventNum);
+// EventDirCreator.createDirWithNum(nextEventNum);
+// EventDirCreator.createPullRequestWithNum(nextEventNum);
 
 const eventDate = moment()
   .day("Saturday")


### PR DESCRIPTION
diff --git a/scripts/Dockerfile b/scripts/Dockerfile
index bc71ea9..4fc3882 100644
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,33 @@
 FROM node:10-alpine

+# https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
+# Installs latest Chromium (77) package.
+RUN apk add --no-cache \
+      chromium \
+      nss \
+      freetype \
+      freetype-dev \
+      harfbuzz \
+      ca-certificates \
+      ttf-freefont \
+      nodejs \
+      yarn
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+# Puppeteer v1.19.0 works with Chromium 77.
+RUN yarn add puppeteer@1.19.0
+
+# Add user so we don't need --no-sandbox.
+RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
+    && mkdir -p /home/pptruser/Downloads /app \
+    && chown -R pptruser:pptruser /home/pptruser \
+    && chown -R pptruser:pptruser /app
+
+# Run everything after as non-privileged user.
+USER pptruser
+
 # Install entrykit
 ENV ENTRYKIT_VERSION 0.4.0
 RUN apk add --no-cache --virtual build-dependencies curl tar git \
@@ -11,8 +39,13 @@ RUN apk add --no-cache --virtual build-dependencies curl tar git \
   && chmod +x /bin/entrykit \
   && entrykit --symlink

+<<<<<<< Updated upstream
 WORKDIR /app
 VOLUME /app/functions/node_modules
+=======
+WORKDIR /src
+VOLUME /src/scripts/node_modules
+>>>>>>> Stashed changes

 ENTRYPOINT [ \
   "prehook", "npm --prefix scripts audit fix", "--", \
diff --git a/scripts/connpass_event_creator.js b/scripts/connpass_event_creator.js
index 7e0430b..c3454e9 100644
--- a/scripts/connpass_event_creator.js
+++ b/scripts/connpass_event_creator.js
@@ -13,7 +13,11 @@ ConnpassEventCreator.create = async settings => {
   const user = process.env.CONNPASS_USER;
   const password = process.env.CONNPASS_PASSWORD;

-  const browser = await puppeteer.launch({ headless: true });
+  // const browser = await puppeteer.launch({ headless: true });
+  const browser = await puppeteer.launch({
+    executablePath: '/usr/bin/chromium-browser',
+    headless: true
+  });
   const page = await browser.newPage();
   await page.setViewport({ width: 1440, height: 766 });

diff --git a/scripts/event_publisher.js b/scripts/event_publisher.js
index 4761975..a592540 100644
--- a/scripts/event_publisher.js
+++ b/scripts/event_publisher.js
@@ -10,8 +10,8 @@ EventDirCreator.setup(process.env.GITHUB_API_TOKEN);

 const nextEventNum = EventDirCreator.getNextEventNum();

-EventDirCreator.createDirWithNum(nextEventNum);
-EventDirCreator.createPullRequestWithNum(nextEventNum);
+// EventDirCreator.createDirWithNum(nextEventNum);
+// EventDirCreator.createPullRequestWithNum(nextEventNum);

 const eventDate = moment()
   .day("Saturday")