### PR TITLE
Fix Slack.get_channel_id

### DIFF
--- a/functions/slack.js
+++ b/functions/slack.js
@@ -24,7 +24,7 @@ Slack.create_channel = (name) => {
 };
 
 Slack.get_channel_id = (name, cursor) => {
-  const data = { token: Slack.token, exclude_archived: true };
+  const data = { token: Slack.token, exclude_archived: true, limit: 1000 };
   if (cursor !== null) { data.cursor = cursor; }
 
   return axios.get(`https://slack.com/api/conversations.list?${querystring.stringify(data)}`).then((response) => {

--- a/scripts/slack.js
+++ b/scripts/slack.js
@@ -28,7 +28,7 @@ Slack.create_channel = name => {
 };
 
 Slack.get_channel_id = (name, cursor) => {
-  const data = { token: Slack.token, exclude_archived: true };
+  const data = { token: Slack.token, exclude_archived: true, limit: 1000 };
   if (cursor !== null) {
     data.cursor = cursor;
   }


### PR DESCRIPTION
## Summary

Fix Slack commands `/presenter`, `/prepare`( and a part of using slack messages).

The problem was that when we using `https://slack.com/api/conversations.list` - this was a limited number of 100 users and exclude archived channels. 
There are 271 slack members alone, today.
This change a limited number to 1000 from 100. `1000` is limit of max number.

ref: [conversations.list method | Slack](https://api.slack.com/methods/conversations.list)